### PR TITLE
Support a large number of files (and some other quick bugfixes)

### DIFF
--- a/NCOpy/tests/test_nco.py
+++ b/NCOpy/tests/test_nco.py
@@ -66,6 +66,7 @@ def test_use_list_inputs(foo_nc, bar_nc):
     nco.ncrcat(input=infiles, output='out.nc')
 
 
+@pytest.mark.usefixtures("foo_nc")
 def test_use_list_options(foo_nc):
     nco = Nco(debug=True)
     options = []
@@ -82,7 +83,7 @@ def test_ncra_mult_files(foo_nc, bar_nc):
     nco.ncra(input=infiles, output='out.nc')
 
 
-@pytest.mark.usefixtures("foo_nc", "bar_nc")
+@pytest.mark.usefixtures("foo_nc")
 def test_ncra_single_file(foo_nc):
     nco = Nco(debug=True)
     infile = foo_nc
@@ -122,13 +123,14 @@ def test_returnArray(foo_nc):
     np.testing.assert_equal(random1, random2)
 
 
-@pytest.mark.usefixtures("bar_mask_nc")
+@pytest.mark.usefixtures("bar_mask_nc", "random_masked_field")
 def test_returnMaArray(bar_mask_nc, random_masked_field):
     nco = Nco()
     field = nco.ncea(input=bar_mask_nc, returnMaArray='random')
     assert type(field) == np.ma.core.MaskedArray
 
 
+@pytest.mark.usefixtures("foo_nc")
 def test_returnCdf(foo_nc):
     nco = Nco(cdfMod='scipy')
     testCdf = nco.ncea(input=foo_nc, returnCdf=True)

--- a/NCOpy/tests/test_nco.py
+++ b/NCOpy/tests/test_nco.py
@@ -107,10 +107,8 @@ def test_ncea_mult_files(foo_nc, bar_nc):
 def test_errorException():
     nco = Nco()
     assert hasattr(nco, 'nonExistingMethod') == False
-    try:
+    with pytest.raises(NCOException):
         nco.ncks(input="", output="")
-    except NCOException:
-        pass
 
 
 @pytest.mark.usefixtures("foo_nc")

--- a/NCOpy/tests/test_nco_examples.py
+++ b/NCOpy/tests/test_nco_examples.py
@@ -16,8 +16,8 @@ def test_ncks_hdf2nc(hdf_file):
     ncks --hdf4 fl.hdf fl.nc # Convert HDF4->netCDF4 (NCO 4.3.7-4.3.9)
     """
     nco = Nco(debug=True)
-    nco.ncks(input=hdf_file, ouput='foo.nc')
-    nco.ncks(input=hdf_file, ouput='foo.nc', hdf4=True)
+    nco.ncks(input=hdf_file, output='foo.nc')
+    nco.ncks(input=hdf_file, output='foo.nc', hdf4=True)
 
 
 def test_ncks_hdf2nc3():
@@ -33,10 +33,10 @@ def test_ncks_hdf2nc3():
     ncks --hdf4 -7 fl.hdf fl.nc # HDF4->netCDF4 classic (netCDF 4.3.0-)
     """
     nco = Nco(debug=True)
-    nco.ncks(input='foo.hdf', ouput='foo.nc', options='-3')
-    nco.ncks(input='foo.hdf', ouput='foo.nc', options='-7 -L 1')
-    nco.ncks(input='foo.hdf', ouput='foo.nc', options='-3', hdf4=True)
-    nco.ncks(input='foo.hdf', ouput='foo.nc', options='-7', hdf4=True)
+    nco.ncks(input='foo.hdf', output='foo.nc', options='-3')
+    nco.ncks(input='foo.hdf', output='foo.nc', options='-7 -L 1')
+    nco.ncks(input='foo.hdf', output='foo.nc', options='-3', hdf4=True)
+    nco.ncks(input='foo.hdf', output='foo.nc', options='-7', hdf4=True)
 
 
 def test_temp_output_files(foo_nc):


### PR DESCRIPTION
I was running into [this](http://nco.sourceforge.net/nco.html#Large-Numbers-of-Files) well documented problem.

The easiest way to test new "large number of files" support is to add a  `raises OSError("foo")` line below line 63 and see the DEBUG commands the tests give out. They do indeed use the "large number of files" code and pass (sorry I didn't write better tests).

The other changes are just things I ran into when running the tests in my dev environment.  All tests passing for me here.